### PR TITLE
got rid of the extra \ character

### DIFF
--- a/file.txt
+++ b/file.txt
@@ -1,1 +1,1 @@
-This is a text file\!
+This is a text file!


### PR DESCRIPTION
You're repository was using a deeply flawed methodology in it's textual representation of what was essentially a string based version of an English sentence. After evaluating the best course of action I decided to fix the aforementioned issues by deleting the "\" character before the exclamation mark. Then I had a sandwich.

Sincerely,
 - mtak-